### PR TITLE
🚨 Replace removed api call in 2023.5

### DIFF
--- a/custom_components/laundry/__init__.py
+++ b/custom_components/laundry/__init__.py
@@ -17,7 +17,7 @@ async def async_setup(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up launpo from a config entry."""
-    hass.config_entries.async_setup_platforms(entry, (Platform.SENSOR,))
+    await hass.config_entries.async_forward_entry_setups(entry, (Platform.SENSOR,))
     _LOGGER.debug(entry)
     print(entry)
 


### PR DESCRIPTION
Starting with 2023.2, HA deprecated async_setup_platforms api call, replacing it with async_forward_entry_setups.
This previous api method has been removed as of 2023.5 leading laundry integration to fail to start.

Reference: https://github.com/hacs/integration/pull/3038